### PR TITLE
Use dates for single station endpoint

### DIFF
--- a/citybikeapp-backend/README.md
+++ b/citybikeapp-backend/README.md
@@ -16,7 +16,7 @@ Loader will only delete used local files when running in `prod` environment. Thi
 in place,
 containers also.
 
-Loader will perform simple validation and cleaning on the data. Anything not matching the assumed format or data model
+Loader will perform simple validation and cleaning on the data. Anything not matching the assumed format or data model,
 will cause the entry to be ignored. Duplicate entries are ignored. For stations the primary key ID is pulled straight
 from source CSV and subsequent INSERTs on same ID is ignored. For journeys the uniqueness in maintained by an all column
 unique constraint/index, a bit doubtful about this... (temp table on insert could work also?)
@@ -25,17 +25,17 @@ Example for running data loader: `./gradlew run --args "dataloader"`
 
 ### Environment variables
 
-This table describes relevant variables when running the final application in production mode. Micronaut allows property
+This table describes relevant variables when running the application in production mode. Micronaut allows property
 overriding using environment variables (like Spring does) but these are explicitly configured.
 
-| Environment variable                 | Description                                     | Default                                                   | Required | Example                                                   |
-|--------------------------------------|-------------------------------------------------|-----------------------------------------------------------|----------|-----------------------------------------------------------|
-| `PORT`                               | Server port                                     | `8080`                                                    |          |                                                           |
-| `DATABASE_CONNECTION_URL`            | JDBC connection URL                             | `jdbc:postgresql://host.docker.internal:5432/citybikeapp` |          | `jdbc:postgresql://foo.bar:5432/packlister`               |
-| `DATABASE_CONNECTION_USERNAME`       | DB username                                     | `postgres`                                                |          | `foo`                                                     |
-| `DATABASE_CONNECTION_PASSWORD`       | DB password                                     | `Hunter2`                                                 |          | `bar`                                                     |
-| `CITYBIKEAPP_DATALOADER_STATIONURL`  | URL for station data CSV file                   | [[1]](#default_station)                                   |          | `http://foo.bar/file.csv`                                 |
-| `CITYBIKEAPP_DATALOADER_JOURNEYURLS` | Comma separated URLs for journey data CSV files | [[2]](#default_journey)                                   |          | `http://foo.bar/journey1.csv,http://foo.bar/journey2.csv` |
+| Environment variable                  | Description                                     | Default                                                   | Required | Example                                                   |
+|---------------------------------------|-------------------------------------------------|-----------------------------------------------------------|----------|-----------------------------------------------------------|
+| `PORT`                                | Server port                                     | `8080`                                                    |          |                                                           |
+| `DATABASE_CONNECTION_URL`             | JDBC connection URL                             | `jdbc:postgresql://host.docker.internal:5432/citybikeapp` |          | `jdbc:postgresql://foo.bar:5432/packlister`               |
+| `DATABASE_CONNECTION_USERNAME`        | DB username                                     | `postgres`                                                |          | `foo`                                                     |
+| `DATABASE_CONNECTION_PASSWORD`        | DB password                                     | `Hunter2`                                                 |          | `bar`                                                     |
+| `CITYBIKEAPP_DATALOADER_STATION_URL`  | URL for station data CSV file                   | [[1]](#default_station)                                   |          | `http://foo.bar/file.csv`                                 |
+| `CITYBIKEAPP_DATALOADER_JOURNEY_URLS` | Comma separated URLs for journey data CSV files | [[2]](#default_journey)                                   |          | `http://foo.bar/journey1.csv,http://foo.bar/journey2.csv` |
 
 <a id="default_station"></a>[1] `https://opendata.arcgis.com/datasets/726277c507ef4914b0aec3cbcfcbfafc_0.csv`
 

--- a/citybikeapp-backend/gen/api.yml
+++ b/citybikeapp-backend/gen/api.yml
@@ -39,7 +39,8 @@ paths:
       - station
       summary: Get single station information with statistics
       description: Single station information including journey statistics. Statistics
-        are filtered using the optional query parameters.
+        are filtered using the optional query parameters. Note that malformed optional
+        query parameters do not result in failure.
       operationId: getStationWithStatistics
       parameters:
       - name: id
@@ -49,20 +50,22 @@ paths:
         schema:
           type: integer
           format: int32
-      - name: from
+      - name: fromDate
         in: query
-        description: Earliest journey time to include in station statistics
+        description: Earliest journey date to include in station statistics
         schema:
           type: string
-          format: date-time
+          format: date
           nullable: true
-      - name: to
+        example: 2021-06-15
+      - name: toDate
         in: query
-        description: Latest journey time to include in station statistics
+        description: Latest journey date to include in station statistics
         schema:
           type: string
-          format: date-time
+          format: date
           nullable: true
+        example: 2021-07-02
       responses:
         "200":
           description: getStationWithStatistics 200 response

--- a/citybikeapp-backend/src/main/resources/application.yml
+++ b/citybikeapp-backend/src/main/resources/application.yml
@@ -40,8 +40,8 @@ citybikeapp:
     batchSize: 1000
     minimumJourneyDistance: 10
     minimumJourneyDuration: 10
-    stationUrl: ${CITYBIKEAPP_DATALOADER_STATIONURL:`https://opendata.arcgis.com/datasets/726277c507ef4914b0aec3cbcfcbfafc_0.csv`}
-    journeyUrls: ${CITYBIKEAPP_DATALOADER_JOURNEYURLS:`https://dev.hsl.fi/citybikes/od-trips-2021/2021-05.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-06.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-07.csv`}
+    stationUrl: ${CITYBIKEAPP_DATALOADER_STATION_URL:`https://opendata.arcgis.com/datasets/726277c507ef4914b0aec3cbcfcbfafc_0.csv`}
+    journeyUrls: ${CITYBIKEAPP_DATALOADER_JOURNEY_URLS:`https://dev.hsl.fi/citybikes/od-trips-2021/2021-05.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-06.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-07.csv`}
 logger:
   levels:
 #    com:

--- a/citybikeapp-frontend/src/components/StationDetails.tsx
+++ b/citybikeapp-frontend/src/components/StationDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { StationStatistics, StationWithStatistics, TopStation } from "generated";
 import { stationApi } from "clients";
 
@@ -16,7 +16,7 @@ const StationDetails = () => {
     };
 
     void getStation();
-  }, []);
+  }, [stationId]);
 
   if (station === undefined) return null;
 
@@ -39,10 +39,10 @@ const StationDetails = () => {
       <h3>{name}</h3>
       {stations.map(station =>
         <div key={station.id}>
-          <span>{station.nameFinnish}, {station.journeyCount} journeys</span>
+          <span><Link to={`/station/${station.id}`}>{station.nameFinnish}</Link>, {station.journeyCount} journeys</span>
         </div>
       )}
-    </div>
+    </div >
   );
 
   return (

--- a/citybikeapp-frontend/webpack.config.js
+++ b/citybikeapp-frontend/webpack.config.js
@@ -8,7 +8,7 @@ const config = (env, argv) => {
 
   const apiBaseUrl = argv.mode === "production"
     ? process.env.API_BASE_URL ?? "/api" // production default
-    : process.env.API_BASE_URL ?? "http://localhost:8080/api"; // dev default
+    : process.env.API_BASE_URL ?? "http://localhost:8080"; // dev default
 
   return {
     entry: "./src/index.tsx",


### PR DESCRIPTION
* Not using datetime even though underlying logic still does so. Date seems neater for frontend usage.
* Remove /api from default frontend API url in development
* Add links to other stations in single station view