### PR TITLE
Add configuration options for data loader, chunk rows after parsing and filtering

### DIFF
--- a/citybikeapp-backend/README.md
+++ b/citybikeapp-backend/README.md
@@ -28,20 +28,30 @@ Example for running data loader: `./gradlew run --args "dataloader"`
 This table describes relevant variables when running the application in production mode. Micronaut allows property
 overriding using environment variables (like Spring does) but these are explicitly configured.
 
-| Environment variable                  | Description                                     | Default                                                   | Required | Example                                                   |
-|---------------------------------------|-------------------------------------------------|-----------------------------------------------------------|----------|-----------------------------------------------------------|
-| `PORT`                                | Server port                                     | `8080`                                                    |          |                                                           |
-| `DATABASE_CONNECTION_URL`             | JDBC connection URL                             | `jdbc:postgresql://host.docker.internal:5432/citybikeapp` |          | `jdbc:postgresql://foo.bar:5432/packlister`               |
-| `DATABASE_CONNECTION_USERNAME`        | DB username                                     | `postgres`                                                |          | `foo`                                                     |
-| `DATABASE_CONNECTION_PASSWORD`        | DB password                                     | `Hunter2`                                                 |          | `bar`                                                     |
-| `CITYBIKEAPP_DATALOADER_STATION_URL`  | URL for station data CSV file                   | [[1]](#default_station)                                   |          | `http://foo.bar/file.csv`                                 |
-| `CITYBIKEAPP_DATALOADER_JOURNEY_URLS` | Comma separated URLs for journey data CSV files | [[2]](#default_journey)                                   |          | `http://foo.bar/journey1.csv,http://foo.bar/journey2.csv` |
+#### Common
+
+| Environment variable                 | Description                                     | Default                                                   | Required | Example                                                   |
+|--------------------------------------|-------------------------------------------------|-----------------------------------------------------------|----------|-----------------------------------------------------------|
+| `PORT`                               | Server port                                     | `8080`                                                    |          |                                                           |
+| `DATABASE_CONNECTION_URL`            | JDBC connection URL                             | `jdbc:postgresql://host.docker.internal:5432/citybikeapp` |          | `jdbc:postgresql://foo.bar:5432/packlister`               |
+| `DATABASE_CONNECTION_USERNAME`       | DB username                                     | `postgres`                                                |          | `foo`                                                     |
+| `DATABASE_CONNECTION_PASSWORD`       | DB password                                     | `Hunter2`                                                 |          | `bar`                                                     |
+
+#### Data loader specific environment variables
+
+| Environment variable                  | Description                                             | Default                 | Required | Example                                                   |
+|---------------------------------------|---------------------------------------------------------|-------------------------|----------|-----------------------------------------------------------|
+| `CITYBIKEAPP_DATALOADER_MIN_DISTANCE` | Minimum filter on journey length (meters)               | `10`                    |          |                                                           |
+| `CITYBIKEAPP_DATALOADER_MIN_DURATION` | Minimum filter on journey duration (seconds)            | `10`                    |          |                                                           |
+| `CITYBIKEAPP_DATALOADER_BATCH_SIZE`   | Database batch size for inserts                         | `1000`                  |          |                                                           |
+| `CITYBIKEAPP_DATALOADER_STATION_URL`  | URL for station data CSV file                           | [[1]](#default_station) |          | `http://foo.bar/file.csv`                                 |
+| `CITYBIKEAPP_DATALOADER_JOURNEY_URLS` | Comma separated list of URLs for journey data CSV files | [[2]](#default_journey) |          | `http://foo.bar/journey1.csv,http://foo.bar/journey2.csv` |
 
 <a id="default_station"></a>[1] `https://opendata.arcgis.com/datasets/726277c507ef4914b0aec3cbcfcbfafc_0.csv`
 
 <a id="default_journey"></a>[2] `https://dev.hsl.fi/citybikes/od-trips-2021/2021-05.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-06.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-07.csv`
 
-#### TODOs
+### TODOs
 
 * Use single testcontainer for all the tests. Even though running the full application is fast (compared to Spring), the
   database container is adding some overhead.

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/Application.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/Application.kt
@@ -22,7 +22,7 @@ object Application {
     @JvmStatic
     fun main(args: Array<String>) {
         if (args.isNotEmpty() && args[0] == "dataloader") {
-            // picocli is not configured to handle "dataloader" arg so not passing anything
+            // picocli is not configured to handle "dataloader" arg (or any others) so not passing anything
             PicocliRunner.run(DataLoader::class.java)
         } else {
             run(*args)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/DataLoader.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/DataLoader.kt
@@ -63,8 +63,8 @@ class DataLoader : Runnable {
 
         reader.open(inputStream) {
             readAllWithHeaderAsSequence()
+                .mapNotNull { parseStation(it) }
                 .chunked(config.batchSize)
-                .map { chunk -> chunk.mapNotNull { parseStation(it) } }
                 .forEach { stationRepository.saveInBatch(it) }
         }
         logger.info { "Stations loaded" }
@@ -77,10 +77,9 @@ class DataLoader : Runnable {
 
             reader.open(inputStream) {
                 readAllWithHeaderAsSequence()
+                    .mapNotNull(::parseJourney)
+                    .filter(::isJourneyValid)
                     .chunked(config.batchSize)
-                    .map { chunk ->
-                        chunk.mapNotNull { parseJourney(it) }.filter { isJourneyValid(it) }
-                    }
                     .forEach { journeyRepository.saveInBatch(it) }
             }
         }

--- a/citybikeapp-backend/src/main/resources/application.yml
+++ b/citybikeapp-backend/src/main/resources/application.yml
@@ -37,9 +37,9 @@ flyway:
       defaultSchema: citybikeapp
 citybikeapp:
   dataLoader:
-    batchSize: 1000
-    minimumJourneyDistance: 10
-    minimumJourneyDuration: 10
+    batchSize: ${CITYBIKEAPP_DATALOADER_BATCH_SIZE:1000}
+    minimumJourneyDistance: ${CITYBIKEAPP_DATALOADER_MIN_DISTANCE:10}
+    minimumJourneyDuration: ${CITYBIKEAPP_DATALOADER_MIN_DURATION:10}
     stationUrl: ${CITYBIKEAPP_DATALOADER_STATION_URL:`https://opendata.arcgis.com/datasets/726277c507ef4914b0aec3cbcfcbfafc_0.csv`}
     journeyUrls: ${CITYBIKEAPP_DATALOADER_JOURNEY_URLS:`https://dev.hsl.fi/citybikes/od-trips-2021/2021-05.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-06.csv,https://dev.hsl.fi/citybikes/od-trips-2021/2021-07.csv`}
 logger:


### PR DESCRIPTION
* Allow more configuration options for data loader through environment variables: min distance, min duration, batch size.
* Chunk processed rows in data loader after parsing and filtering so database batch size remains consistently at configured value.