### PR TITLE
Restructuring backend

### DIFF
--- a/citybikeapp-backend/README.md
+++ b/citybikeapp-backend/README.md
@@ -18,8 +18,8 @@ containers also.
 
 Loader will perform simple validation and cleaning on the data. Anything not matching the assumed format or data model,
 will cause the entry to be ignored. Duplicate entries are ignored. For stations the primary key ID is pulled straight
-from source CSV and subsequent INSERTs on same ID is ignored. For journeys the uniqueness in maintained by an all column
-unique constraint/index, a bit doubtful about this... (temp table on insert could work also?)
+from source CSV and subsequent INSERTs on same ID are ignored. For journeys the uniqueness in maintained by an all
+column unique constraint/index, a bit doubtful about this... (temp table on insert could work also?)
 
 Example for running data loader: `./gradlew run --args "dataloader"`
 
@@ -39,13 +39,13 @@ overriding using environment variables (like Spring does) but these are explicit
 
 #### Data loader specific environment variables
 
-| Environment variable                  | Description                                             | Default                 | Required | Example                                                   |
-|---------------------------------------|---------------------------------------------------------|-------------------------|----------|-----------------------------------------------------------|
-| `CITYBIKEAPP_DATALOADER_MIN_DISTANCE` | Minimum filter on journey length (meters)               | `10`                    |          |                                                           |
-| `CITYBIKEAPP_DATALOADER_MIN_DURATION` | Minimum filter on journey duration (seconds)            | `10`                    |          |                                                           |
-| `CITYBIKEAPP_DATALOADER_BATCH_SIZE`   | Database batch size for inserts                         | `1000`                  |          |                                                           |
-| `CITYBIKEAPP_DATALOADER_STATION_URL`  | URL for station data CSV file                           | [[1]](#default_station) |          | `http://foo.bar/file.csv`                                 |
-| `CITYBIKEAPP_DATALOADER_JOURNEY_URLS` | Comma separated list of URLs for journey data CSV files | [[2]](#default_journey) |          | `http://foo.bar/journey1.csv,http://foo.bar/journey2.csv` |
+| Environment variable                  | Description                                             | Default                 | Example                                                   |
+|---------------------------------------|---------------------------------------------------------|-------------------------|-----------------------------------------------------------|
+| `CITYBIKEAPP_DATALOADER_MIN_DISTANCE` | Minimum filter on journey length (meters)               | `10`                    |                                                           |
+| `CITYBIKEAPP_DATALOADER_MIN_DURATION` | Minimum filter on journey duration (seconds)            | `10`                    |                                                           |
+| `CITYBIKEAPP_DATALOADER_BATCH_SIZE`   | Database batch size for inserts                         | `1000`                  |                                                           |
+| `CITYBIKEAPP_DATALOADER_STATION_URL`  | URL for station data CSV file                           | [[1]](#default_station) | `http://foo.bar/file.csv`                                 |
+| `CITYBIKEAPP_DATALOADER_JOURNEY_URLS` | Comma separated list of URLs for journey data CSV files | [[2]](#default_journey) | `http://foo.bar/journey1.csv,http://foo.bar/journey2.csv` |
 
 <a id="default_station"></a>[1] `https://opendata.arcgis.com/datasets/726277c507ef4914b0aec3cbcfcbfafc_0.csv`
 

--- a/citybikeapp-backend/build.gradle.kts
+++ b/citybikeapp-backend/build.gradle.kts
@@ -58,8 +58,9 @@ dependencies {
     runtimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("org.assertj:assertj-core")
-    testImplementation("org.mockito:mockito-core")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+//    testImplementation("org.mockito:mockito-core")
+//    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+    testImplementation("io.mockk:mockk")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:testcontainers")

--- a/citybikeapp-backend/gen/api.yml
+++ b/citybikeapp-backend/gen/api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: City Bike App API
-  version: 0.0.3
+  version: 0.0.4a
 paths:
   /health:
     get:
@@ -117,8 +117,8 @@ components:
       - arrivalJourneyAverageDistance
       - departureCount
       - departureJourneyAverageDistance
-      - topStationsWhereJourneysArriveFrom
-      - topStationsWhereJourneysDepartTo
+      - topStationsForArrivingHere
+      - topStationsForDepartingTo
       type: object
       properties:
         departureCount:
@@ -133,11 +133,11 @@ components:
         arrivalJourneyAverageDistance:
           type: number
           format: double
-        topStationsWhereJourneysArriveFrom:
+        topStationsForArrivingHere:
           type: array
           items:
             $ref: '#/components/schemas/TopStation'
-        topStationsWhereJourneysDepartTo:
+        topStationsForDepartingTo:
           type: array
           items:
             $ref: '#/components/schemas/TopStation'

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/Application.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/Application.kt
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.info.Info
 @OpenAPIDefinition(
     info = Info(
         title = "City Bike App API",
-        version = "0.0.3"
+        version = "0.0.4a"
     )
 )
 @OpenAPIInclude(classes = [HealthEndpoint::class])

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/DataLoader.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/DataLoader.kt
@@ -1,10 +1,11 @@
 package com.mtuomiko.citybikeapp
 
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
-import com.mtuomiko.citybikeapp.dao.JourneyRepository
-import com.mtuomiko.citybikeapp.dao.StationRepository
-import com.mtuomiko.citybikeapp.model.JourneyNew
-import com.mtuomiko.citybikeapp.model.StationNew
+import com.mtuomiko.citybikeapp.common.TIMEZONE
+import com.mtuomiko.citybikeapp.common.model.JourneyNew
+import com.mtuomiko.citybikeapp.common.model.StationNew
+import com.mtuomiko.citybikeapp.dao.repository.JourneyRepository
+import com.mtuomiko.citybikeapp.dao.repository.StationRepository
 import io.micronaut.context.env.Environment
 import jakarta.inject.Inject
 import mu.KotlinLogging

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
@@ -1,4 +1,4 @@
-package com.mtuomiko.citybikeapp.api
+package com.mtuomiko.citybikeapp.api.model
 
 import io.micronaut.serde.annotation.Serdeable
 
@@ -25,8 +25,8 @@ class StationStatistics(
     val arrivalCount: Long,
     val departureJourneyAverageDistance: Double,
     val arrivalJourneyAverageDistance: Double,
-    val topStationsWhereJourneysArriveFrom: List<TopStation>,
-    val topStationsWhereJourneysDepartTo: List<TopStation>
+    val topStationsForArrivingHere: List<TopStation>,
+    val topStationsForDepartingTo: List<TopStation>
 )
 
 @Serdeable

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/Constants.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/Constants.kt
@@ -1,4 +1,4 @@
-package com.mtuomiko.citybikeapp
+package com.mtuomiko.citybikeapp.common
 
 import java.time.ZoneId
 

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/Journey.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/Journey.kt
@@ -1,4 +1,4 @@
-package com.mtuomiko.citybikeapp.model
+package com.mtuomiko.citybikeapp.common.model
 
 import io.micronaut.serde.annotation.Serdeable
 import java.time.Instant
@@ -12,5 +12,4 @@ data class Journey(
     val returnStation: Station,
     val distance: Int,
     val duration: Int
-
 )

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/JourneyNew.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/JourneyNew.kt
@@ -1,4 +1,4 @@
-package com.mtuomiko.citybikeapp.model
+package com.mtuomiko.citybikeapp.common.model
 
 import java.time.Instant
 

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/Station.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/Station.kt
@@ -1,7 +1,10 @@
-package com.mtuomiko.citybikeapp.model
+package com.mtuomiko.citybikeapp.common.model
 
-data class StationNew(
-    val id: Int?,
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+data class Station(
+    val id: Int,
     val nameFinnish: String,
     val nameSwedish: String,
     val nameEnglish: String,

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/StationNew.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/StationNew.kt
@@ -1,10 +1,7 @@
-package com.mtuomiko.citybikeapp.model
+package com.mtuomiko.citybikeapp.common.model
 
-import io.micronaut.serde.annotation.Serdeable
-
-@Serdeable
-data class Station(
-    val id: Int,
+data class StationNew(
+    val id: Int?,
     val nameFinnish: String,
     val nameSwedish: String,
     val nameEnglish: String,

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/TopStation.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/TopStation.kt
@@ -1,0 +1,9 @@
+package com.mtuomiko.citybikeapp.common.model
+
+class TopStation(
+    val id: Int,
+    val nameFinnish: String,
+    val nameSwedish: String,
+    val nameEnglish: String,
+    val journeyCount: Long
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StationDao.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StationDao.kt
@@ -1,0 +1,30 @@
+package com.mtuomiko.citybikeapp.dao
+
+import com.mtuomiko.citybikeapp.common.model.Station
+import com.mtuomiko.citybikeapp.dao.entity.StationEntity
+import com.mtuomiko.citybikeapp.dao.repository.StationRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+
+@Singleton
+class StationDao(
+    @Inject private val stationRepository: StationRepository
+) {
+    fun getStationById(stationId: Int): Station? = stationRepository.findById(stationId)
+        .orElse(null)?.toModel()
+
+    private fun StationEntity.toModel(): Station = Station(
+        id,
+        nameFinnish,
+        nameSwedish,
+        nameEnglish,
+        addressFinnish,
+        addressSwedish,
+        cityFinnish,
+        citySwedish,
+        operator,
+        capacity,
+        longitude,
+        latitude
+    )
+}

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDao.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDao.kt
@@ -1,0 +1,32 @@
+package com.mtuomiko.citybikeapp.dao
+
+import com.mtuomiko.citybikeapp.common.model.TopStation
+import com.mtuomiko.citybikeapp.dao.model.TopStations
+import com.mtuomiko.citybikeapp.dao.repository.JourneyRepository
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.Instant
+
+@Singleton
+class StatisticsDao(
+    @Inject private val journeyRepository: JourneyRepository
+) {
+    fun getJourneyStatisticsByStationId(stationId: Int, from: Instant?, to: Instant?) =
+        journeyRepository.getJourneyStatisticsByStationId(stationId, from, to)
+
+    fun getTopStationsByStationId(stationId: Int, from: Instant?, to: Instant?): TopStations {
+        val topStationsQueryResult = journeyRepository.getTopStationsByStationId(stationId, from, to)
+
+        val arrivalStations = topStationsQueryResult
+            .filter { it.arrivalStationId == stationId }
+            .sortedByDescending { it.journeyCount }
+            .map { with(it) { TopStation(departureStationId, nameFinnish, nameSwedish, nameEnglish, journeyCount) } }
+
+        val departureStations = topStationsQueryResult
+            .filter { it.departureStationId == stationId }
+            .sortedByDescending { it.journeyCount }
+            .map { with(it) { TopStation(arrivalStationId, nameFinnish, nameSwedish, nameEnglish, journeyCount) } }
+
+        return TopStations(forArrivingHere = arrivalStations, forDepartingTo = departureStations)
+    }
+}

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/mapper/StatisticsMappers.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/mapper/StatisticsMappers.kt
@@ -1,7 +1,7 @@
 package com.mtuomiko.citybikeapp.dao.mapper
 
-import com.mtuomiko.citybikeapp.dao.JourneyStatistics
-import com.mtuomiko.citybikeapp.dao.TopStationsResult
+import com.mtuomiko.citybikeapp.dao.model.JourneyStatistics
+import com.mtuomiko.citybikeapp.dao.model.TopStationsQueryResult
 import org.jdbi.v3.core.mapper.RowMapper
 import org.jdbi.v3.core.statement.StatementContext
 import java.sql.ResultSet
@@ -17,8 +17,8 @@ class JourneyStatisticsMapper : RowMapper<JourneyStatistics> {
 }
 
 @Suppress("MagicNumber")
-class TopStationsMapper : RowMapper<TopStationsResult> {
-    override fun map(resultSet: ResultSet, ctx: StatementContext) = TopStationsResult(
+class TopStationsMapper : RowMapper<TopStationsQueryResult> {
+    override fun map(resultSet: ResultSet, ctx: StatementContext) = TopStationsQueryResult(
         departureStationId = resultSet.getInt(1),
         arrivalStationId = resultSet.getInt(2),
         journeyCount = resultSet.getLong(3),

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/JourneyStatistics.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/JourneyStatistics.kt
@@ -1,4 +1,4 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.model
 
 class JourneyStatistics(
     val departureCount: Long,

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/StationInsert.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/StationInsert.kt
@@ -1,6 +1,6 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.model
 
-import com.mtuomiko.citybikeapp.model.StationNew
+import com.mtuomiko.citybikeapp.common.model.StationNew
 import java.time.Instant
 
 data class StationInsert(

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/TopStationsQueryResult.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/TopStationsQueryResult.kt
@@ -1,14 +1,21 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.model
+
+import com.mtuomiko.citybikeapp.common.model.TopStation
 
 /**
  * List is in relation to a specific station. The names are always for the *other* station, not for the station which is
  * being queried (unless they happen to be the same station).
  */
-class TopStationsResult(
+class TopStationsQueryResult(
     val departureStationId: Int,
     val arrivalStationId: Int,
     val journeyCount: Long,
     val nameFinnish: String,
     val nameSwedish: String,
     val nameEnglish: String
+)
+
+class TopStations(
+    val forArrivingHere: List<TopStation>,
+    val forDepartingTo: List<TopStation>
 )

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/JourneyRepository.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/JourneyRepository.kt
@@ -1,9 +1,11 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.repository
 
+import com.mtuomiko.citybikeapp.common.model.JourneyNew
 import com.mtuomiko.citybikeapp.dao.entity.JourneyEntity
 import com.mtuomiko.citybikeapp.dao.mapper.JourneyStatisticsMapper
 import com.mtuomiko.citybikeapp.dao.mapper.TopStationsMapper
-import com.mtuomiko.citybikeapp.model.JourneyNew
+import com.mtuomiko.citybikeapp.dao.model.JourneyStatistics
+import com.mtuomiko.citybikeapp.dao.model.TopStationsQueryResult
 import io.micronaut.data.annotation.Join
 import io.micronaut.data.annotation.repeatable.JoinSpecifications
 import io.micronaut.data.jdbc.annotation.JdbcRepository
@@ -57,7 +59,7 @@ abstract class JourneyRepository(
     }
 
     @Transactional
-    fun getTripStatisticsByStationId(stationId: Int, from: Instant? = null, to: Instant? = null): JourneyStatistics {
+    fun getJourneyStatisticsByStationId(stationId: Int, from: Instant? = null, to: Instant? = null): JourneyStatistics {
         val sql = """
             SELECT 
                 COUNT(*) FILTER (WHERE departure_station_id = :stationId) as departure_count,
@@ -90,7 +92,7 @@ abstract class JourneyRepository(
         from: Instant? = null,
         to: Instant? = null,
         limitPerDirection: Int = 5
-    ): List<TopStationsResult> {
+    ): List<TopStationsQueryResult> {
         val sql = """
             SELECT departure_station_id, arrival_station_id, journeys, name_finnish, name_swedish, name_english
             FROM (

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/StationRepository.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/StationRepository.kt
@@ -1,7 +1,8 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.repository
 
+import com.mtuomiko.citybikeapp.common.model.StationNew
 import com.mtuomiko.citybikeapp.dao.entity.StationEntity
-import com.mtuomiko.citybikeapp.model.StationNew
+import com.mtuomiko.citybikeapp.dao.model.StationInsert
 import io.micronaut.data.jdbc.annotation.JdbcRepository
 import io.micronaut.data.repository.PageableRepository
 import org.jdbi.v3.core.Jdbi

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/svc/StationService.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/svc/StationService.kt
@@ -1,0 +1,37 @@
+package com.mtuomiko.citybikeapp.svc
+
+import com.mtuomiko.citybikeapp.common.TIMEZONE
+import com.mtuomiko.citybikeapp.dao.StationDao
+import com.mtuomiko.citybikeapp.dao.StatisticsDao
+import com.mtuomiko.citybikeapp.svc.model.StationStatistics
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Singleton
+class StationService(
+    @Inject private val stationDao: StationDao,
+    @Inject private val statisticsDao: StatisticsDao
+) {
+    fun getStationById(stationId: Int) = stationDao.getStationById(stationId)
+
+    fun getStationStatistics(stationId: Int, fromDate: LocalDate?, toDate: LocalDate?): StationStatistics {
+        // Interpret query dates to be in local Helsinki time
+        val from = fromDate?.atStartOfDay(TIMEZONE)?.toInstant()
+        val to = toDate?.atTime(LocalTime.MAX)?.atZone(TIMEZONE)?.toInstant()
+
+        // TODO: Async handling of queries?
+        val journeyStatistics = statisticsDao.getJourneyStatisticsByStationId(stationId, from, to)
+        val topStations = statisticsDao.getTopStationsByStationId(stationId, from, to)
+
+        return StationStatistics(
+            departureCount = journeyStatistics.departureCount,
+            arrivalCount = journeyStatistics.arrivalCount,
+            departureAverageDistance = journeyStatistics.departureAverageDistance,
+            arrivalAverageDistance = journeyStatistics.arrivalAverageDistance,
+            topStationsForArrivingHere = topStations.forArrivingHere,
+            topStationsForDepartingTo = topStations.forDepartingTo
+        )
+    }
+}

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/svc/model/StationStatistics.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/svc/model/StationStatistics.kt
@@ -1,0 +1,12 @@
+package com.mtuomiko.citybikeapp.svc.model
+
+import com.mtuomiko.citybikeapp.common.model.TopStation
+
+class StationStatistics(
+    val departureCount: Long,
+    val arrivalCount: Long,
+    val departureAverageDistance: Double,
+    val arrivalAverageDistance: Double,
+    val topStationsForArrivingHere: List<TopStation>,
+    val topStationsForDepartingTo: List<TopStation>
+)

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/DataLoaderProductionEnvironmentTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/DataLoaderProductionEnvironmentTest.kt
@@ -4,12 +4,11 @@ import io.micronaut.configuration.picocli.PicocliRunner
 import io.micronaut.context.ApplicationContext
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 @MicronautTest(environments = ["test", "prod"])
 class DataLoaderProductionEnvironmentTest {
@@ -24,13 +23,13 @@ class DataLoaderProductionEnvironmentTest {
     fun `When running in production environment, data loader will call for file deletion`() {
         PicocliRunner.run(DataLoader::class.java, applicationContext)
 
-        verify(fileProvider).deleteFiles()
+        verify(exactly = 1) { fileProvider.deleteFiles() }
     }
 
     @MockBean(DownloadingFileProvider::class)
     private fun fileProvider(): FileProvider {
-        val mock: FileProvider = mock()
-        whenever(mock.getLocalInputStream(any())).thenReturn("".byteInputStream())
-        return mock
+        val mockProvider = mockk<FileProvider>(relaxUnitFun = true)
+        every { mockProvider.getLocalInputStream(any()) } returns "".byteInputStream()
+        return mockProvider
     }
 }

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/DataLoaderTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/DataLoaderTest.kt
@@ -1,7 +1,7 @@
 package com.mtuomiko.citybikeapp
 
-import com.mtuomiko.citybikeapp.dao.JourneyRepository
-import com.mtuomiko.citybikeapp.dao.StationRepository
+import com.mtuomiko.citybikeapp.dao.repository.JourneyRepository
+import com.mtuomiko.citybikeapp.dao.repository.StationRepository
 import io.micronaut.configuration.picocli.PicocliRunner
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Property

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/JourneyRepositoryTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/JourneyRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.mtuomiko.citybikeapp.dao
 
+import com.mtuomiko.citybikeapp.dao.repository.JourneyRepository
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.Test
@@ -14,7 +15,7 @@ class JourneyRepositoryTest(
      */
     @Test
     fun `Trip statistics query can be run`() {
-        val result = journeyRepository.getTripStatisticsByStationId(100)
+        val result = journeyRepository.getJourneyStatisticsByStationId(100)
     }
 
     @Test

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StationRepositoryTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StationRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.mtuomiko.citybikeapp.dao
 
 import com.mtuomiko.citybikeapp.dao.entity.StationEntity
+import com.mtuomiko.citybikeapp.dao.repository.StationRepository
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDaoTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDaoTest.kt
@@ -1,0 +1,46 @@
+package com.mtuomiko.citybikeapp.dao
+
+import com.mtuomiko.citybikeapp.dao.repository.JourneyRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StatisticsDaoTest {
+    private val journeyRepository = mockk<JourneyRepository>()
+    private val statisticsDao = StatisticsDao(journeyRepository)
+
+    @Test
+    fun `Top stations are split and sorted according to arriving and departing station ids and journey count `() {
+        val testStationId = 1
+        val testQueryResults = List(6) {
+            TopStationsQueryResultBuilder().departureStationId(testStationId).arrivalStationId(100 + it)
+                .journeyCount(1000L * (it + 1))
+                .build()
+        } + List(6) {
+            TopStationsQueryResultBuilder().arrivalStationId(testStationId).departureStationId(200 + it)
+                .journeyCount(100L * (it + 1))
+                .build()
+        }
+
+        every { journeyRepository.getTopStationsByStationId(testStationId) } returns testQueryResults
+
+        val result = statisticsDao.getTopStationsByStationId(testStationId, null, null)
+
+        val expectedStationIdsWhereDepartedFrom =
+            testQueryResults.filter { it.arrivalStationId == testStationId }.sortedByDescending { it.journeyCount }
+                .map { it.departureStationId }
+        val expectedStationIdsWhereArrivedTo =
+            testQueryResults.filter { it.departureStationId == testStationId }.sortedByDescending { it.journeyCount }
+                .map { it.arrivalStationId }
+
+        // expect descending order
+        assertThat(result.forArrivingHere).hasSize(6)
+        assertThat(result.forArrivingHere).isSortedAccordingTo { o1, o2 -> (o2.journeyCount - o1.journeyCount).toInt() }
+        assertThat(result.forArrivingHere.map { it.id }).containsExactlyElementsOf(expectedStationIdsWhereDepartedFrom)
+
+        assertThat(result.forDepartingTo).hasSize(6)
+        assertThat(result.forDepartingTo).isSortedAccordingTo { o1, o2 -> (o2.journeyCount - o1.journeyCount).toInt() }
+        assertThat(result.forDepartingTo.map { it.id }).containsExactlyElementsOf(expectedStationIdsWhereArrivedTo)
+    }
+}

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/TopStationsQueryResultBuilder.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/TopStationsQueryResultBuilder.kt
@@ -1,0 +1,25 @@
+package com.mtuomiko.citybikeapp.dao
+
+import com.mtuomiko.citybikeapp.dao.model.TopStationsQueryResult
+
+class TopStationsQueryResultBuilder {
+    var departureStationId: Int = 1
+    var arrivalStationId: Int = 2
+    var journeyCount: Long = (1..100).random().toLong()
+    var nameFinnish: String = "Asema"
+    var nameSwedish: String = "Station"
+    var nameEnglish: String = "Station"
+
+    fun build() = TopStationsQueryResult(
+        departureStationId,
+        arrivalStationId,
+        journeyCount,
+        nameFinnish,
+        nameSwedish,
+        nameEnglish
+    )
+
+    fun departureStationId(id: Int) = apply { this.departureStationId = id }
+    fun arrivalStationId(id: Int) = apply { this.arrivalStationId = id }
+    fun journeyCount(count: Long) = apply { this.journeyCount = count }
+}

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/svc/StationServiceTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/svc/StationServiceTest.kt
@@ -1,0 +1,54 @@
+package com.mtuomiko.citybikeapp.svc
+
+import com.mtuomiko.citybikeapp.common.TIMEZONE
+import com.mtuomiko.citybikeapp.dao.StationDao
+import com.mtuomiko.citybikeapp.dao.StatisticsDao
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+class StationServiceTest {
+    private val stationDao = mockk<StationDao>()
+    private val statisticsDao = mockk<StatisticsDao>()
+    private val stationService = StationService(stationDao, statisticsDao)
+    private val timezone = ZoneId.of("Europe/Helsinki")
+
+    @Test
+    fun `When station statistics are called with date args, DAO is called with Helsinki zoned timestamps`() {
+        val id = 66
+        val summerDate = LocalDate.parse("2018-07-03")
+        val winterDate = LocalDate.parse("2019-01-09")
+        val intCaptor = mutableListOf<Int>()
+        val instantCaptor = mutableListOf<Instant>()
+
+        every {
+            statisticsDao.getJourneyStatisticsByStationId(
+                capture(intCaptor),
+                capture(instantCaptor),
+                capture(instantCaptor)
+            )
+        } returns mockk(relaxed = true)
+        every {
+            statisticsDao.getTopStationsByStationId(
+                capture(intCaptor),
+                capture(instantCaptor),
+                capture(instantCaptor)
+            )
+        } returns mockk(relaxed = true)
+
+        stationService.getStationStatistics(stationId = id, fromDate = summerDate, toDate = winterDate)
+
+        val expectedFrom = summerDate.atTime(LocalTime.MIDNIGHT).atZone(timezone).toInstant()
+        val expectedTo = winterDate.atTime(LocalTime.MAX).atZone(TIMEZONE).toInstant()
+        assertThat(intCaptor).hasSize(2)
+        assertThat(intCaptor).allMatch { it == id }
+        assertThat(instantCaptor).hasSize(4)
+        assertThat(listOf(instantCaptor[0], instantCaptor[2])).allMatch { it == expectedFrom }
+        assertThat(listOf(instantCaptor[1], instantCaptor[3])).allMatch { it == expectedTo }
+    }
+}

--- a/citybikeapp-frontend/src/components/StationDetails.tsx
+++ b/citybikeapp-frontend/src/components/StationDetails.tsx
@@ -29,8 +29,8 @@ const StationDetails = () => {
         <li>departureJourneyAverageDistance {statistics.departureJourneyAverageDistance}</li>
         <li>arrivalJourneyAverageDistance {statistics.arrivalJourneyAverageDistance}</li>
       </ul>
-      {topStations("Most popular stations where people arrive from", statistics.topStationsWhereJourneysArriveFrom)}
-      {topStations("Most popular stations where people go to", statistics.topStationsWhereJourneysDepartTo)}
+      {topStations("Most popular stations where people arrive from", statistics.topStationsForArrivingHere)}
+      {topStations("Most popular stations where people go to", statistics.topStationsForDepartingTo)}
     </>
   );
 


### PR DESCRIPTION
* Split logic and models between API-SVC-DAO layers. A bit verbose but should have better separation: for example API models that define HTTP responses bodies are not handled elsewhere and so on.