### PR TITLE
Add station endpoints and use listing in frontend

### DIFF
--- a/citybikeapp-backend/README.md
+++ b/citybikeapp-backend/README.md
@@ -30,12 +30,13 @@ overriding using environment variables (like Spring does) but these are explicit
 
 #### Common
 
-| Environment variable                 | Description                                     | Default                                                   | Required | Example                                                   |
-|--------------------------------------|-------------------------------------------------|-----------------------------------------------------------|----------|-----------------------------------------------------------|
-| `PORT`                               | Server port                                     | `8080`                                                    |          |                                                           |
-| `DATABASE_CONNECTION_URL`            | JDBC connection URL                             | `jdbc:postgresql://host.docker.internal:5432/citybikeapp` |          | `jdbc:postgresql://foo.bar:5432/packlister`               |
-| `DATABASE_CONNECTION_USERNAME`       | DB username                                     | `postgres`                                                |          | `foo`                                                     |
-| `DATABASE_CONNECTION_PASSWORD`       | DB password                                     | `Hunter2`                                                 |          | `bar`                                                     |
+| Environment variable            | Description                                  | Default                                                   | Required | Example                                     |
+|---------------------------------|----------------------------------------------|-----------------------------------------------------------|----------|---------------------------------------------|
+| `PORT`                          | Server port                                  | `8080`                                                    |          |                                             |
+| `DATABASE_CONNECTION_URL`       | JDBC connection URL                          | `jdbc:postgresql://host.docker.internal:5432/citybikeapp` |          | `jdbc:postgresql://foo.bar:5432/packlister` |
+| `DATABASE_CONNECTION_USERNAME`  | DB username                                  | `postgres`                                                |          | `foo`                                       |
+| `DATABASE_CONNECTION_PASSWORD`  | DB password                                  | `Hunter2`                                                 |          | `bar`                                       |
+| `CITYBIKEAPP_DEFAULT_PAGE_SIZE` | Default page size used in paginating queries | `50`                                                      |          |                                             |
 
 #### Data loader specific environment variables
 

--- a/citybikeapp-backend/gen/api.yml
+++ b/citybikeapp-backend/gen/api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: City Bike App API
-  version: 0.0.5a
+  version: 0.0.6a
 paths:
   /health:
     get:
@@ -33,14 +33,62 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/HealthResult'
+  /station:
+    get:
+      tags:
+      - station
+      summary: Get stations using pagination and optional text search.
+      description: Returns multiple stations with a maximum page size of 50. Page
+        offset can be provided to paginate results. Optional search string can be
+        used to limit matches.
+      operationId: getStations
+      parameters:
+      - name: search
+        in: query
+        description: Optional search string to limit station results. Will look for
+          matches in station names and street addresses. Separate search words with
+          + symbol.
+        schema:
+          type: string
+          nullable: true
+        example: kontu+tie
+      - name: page
+        in: query
+        description: Optional pagination offset.
+        schema:
+          type: integer
+          format: int32
+          nullable: true
+        example: "50"
+      responses:
+        "200":
+          description: getStations 200 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StationsResponse'
+  /station/limited:
+    get:
+      tags:
+      - station
+      summary: Get all stations
+      description: Get all stations with limited information
+      operationId: getAllStationsLimited
+      responses:
+        "200":
+          description: getAllStationsLimited 200 response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StationsLimitedResponse'
   /station/{id}:
     get:
       tags:
       - station
       summary: Get single station information with statistics
       description: Single station information including journey statistics. Statistics
-        are filtered using the optional query parameters. Note that malformed optional
-        query parameters do not result in failure.
+        are filtered using the optional query parameters. Note that malformed query
+        parameters do not result in failure.
       operationId: getStationWithStatistics
       parameters:
       - name: id
@@ -111,6 +159,30 @@ components:
           nullable: true
     Object:
       type: object
+    Station:
+      required:
+      - addressFinnish
+      - capacity
+      - cityFinnish
+      - id
+      - nameFinnish
+      - operator
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        nameFinnish:
+          type: string
+        addressFinnish:
+          type: string
+        cityFinnish:
+          type: string
+        operator:
+          type: string
+        capacity:
+          type: integer
+          format: int32
     StationDetails:
       required:
       - addressFinnish
@@ -165,6 +237,17 @@ components:
           $ref: '#/components/schemas/StationDetails'
         statistics:
           $ref: '#/components/schemas/StationStatistics'
+    StationLimited:
+      required:
+      - id
+      - nameFinnish
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        nameFinnish:
+          type: string
     StationStatistics:
       required:
       - arrivalAverageDistance
@@ -195,6 +278,24 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TopStation'
+    StationsLimitedResponse:
+      required:
+      - stations
+      type: object
+      properties:
+        stations:
+          type: array
+          items:
+            $ref: '#/components/schemas/StationLimited'
+    StationsResponse:
+      required:
+      - stations
+      type: object
+      properties:
+        stations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Station'
     TopStation:
       required:
       - id

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/mapper/StationAPIMapper.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/mapper/StationAPIMapper.kt
@@ -1,9 +1,13 @@
 package com.mtuomiko.citybikeapp.api.mapper
 
+import com.mtuomiko.citybikeapp.api.model.APIStation
 import com.mtuomiko.citybikeapp.api.model.APIStationDetails
+import com.mtuomiko.citybikeapp.api.model.APIStationLimited
 import com.mtuomiko.citybikeapp.api.model.APIStationStatistics
 import com.mtuomiko.citybikeapp.api.model.APITopStation
+import com.mtuomiko.citybikeapp.common.model.Station
 import com.mtuomiko.citybikeapp.common.model.StationDetails
+import com.mtuomiko.citybikeapp.common.model.StationLimited
 import com.mtuomiko.citybikeapp.common.model.TopStation
 import com.mtuomiko.citybikeapp.svc.model.StationStatistics
 import org.mapstruct.Mapper
@@ -12,6 +16,8 @@ import org.mapstruct.Mapper
 interface StationAPIMapper {
 
     fun toApi(stationDetails: StationDetails): APIStationDetails
+    fun toApi(station: Station): APIStation
+    fun toApi(stationLimited: StationLimited): APIStationLimited
 
     fun toApi(stationStatistics: StationStatistics): APIStationStatistics
 

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
@@ -3,8 +3,8 @@ package com.mtuomiko.citybikeapp.api.model
 import io.micronaut.serde.annotation.Serdeable
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(name = "StationDetails")
 @Serdeable
+@Schema(name = "StationDetails")
 data class APIStationDetails(
     val id: Int,
     val nameFinnish: String,
@@ -20,9 +20,27 @@ data class APIStationDetails(
     val latitude: Double
 )
 
-@Schema(name = "StationStatistics")
 @Serdeable
-class APIStationStatistics(
+@Schema(name = "Station")
+data class APIStation(
+    val id: Int,
+    val nameFinnish: String,
+    val addressFinnish: String,
+    val cityFinnish: String,
+    val operator: String,
+    val capacity: Int
+)
+
+@Serdeable
+@Schema(name = "StationLimited")
+data class APIStationLimited(
+    val id: Int,
+    val nameFinnish: String
+)
+
+@Serdeable
+@Schema(name = "StationStatistics")
+data class APIStationStatistics(
     val departureCount: Long,
     val arrivalCount: Long,
     val departureAverageDistance: Double,
@@ -31,8 +49,8 @@ class APIStationStatistics(
     val topStationsForDepartingTo: List<APITopStation>
 )
 
-@Schema(name = "TopStation")
 @Serdeable
+@Schema(name = "TopStation")
 class APITopStation(
     val id: Int,
     val nameFinnish: String,

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/Responses.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/Responses.kt
@@ -1,0 +1,19 @@
+package com.mtuomiko.citybikeapp.api.model
+
+import io.micronaut.serde.annotation.Serdeable
+
+@Serdeable
+data class StationDetailsWithStatisticsResponse(
+    val station: APIStationDetails,
+    val statistics: APIStationStatistics
+)
+
+@Serdeable
+data class StationsLimitedResponse(
+    val stations: List<APIStationLimited>
+)
+
+@Serdeable
+class StationsResponse(
+    val stations: List<APIStation>
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/StationDetailsWithStatisticsResponse.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/StationDetailsWithStatisticsResponse.kt
@@ -1,9 +1,0 @@
-package com.mtuomiko.citybikeapp.api.model
-
-import io.micronaut.serde.annotation.Serdeable
-
-@Serdeable
-class StationDetailsWithStatisticsResponse(
-    val station: APIStationDetails,
-    val statistics: APIStationStatistics
-)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/Station.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/Station.kt
@@ -1,0 +1,10 @@
+package com.mtuomiko.citybikeapp.common.model
+
+class Station(
+    val id: Int,
+    val nameFinnish: String,
+    val addressFinnish: String,
+    val cityFinnish: String,
+    val operator: String,
+    val capacity: Int
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/StationDetails.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/StationDetails.kt
@@ -1,9 +1,6 @@
 package com.mtuomiko.citybikeapp.common.model
 
-import io.micronaut.serde.annotation.Serdeable
-
-@Serdeable
-data class StationDetails(
+class StationDetails(
     val id: Int,
     val nameFinnish: String,
     val nameSwedish: String,

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/StationLimited.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/model/StationLimited.kt
@@ -1,0 +1,6 @@
+package com.mtuomiko.citybikeapp.common.model
+
+class StationLimited(
+    val id: Int,
+    val nameFinnish: String
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/PaginationConfig.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/PaginationConfig.kt
@@ -1,0 +1,9 @@
+package com.mtuomiko.citybikeapp.dao
+
+import io.micronaut.context.annotation.ConfigurationInject
+import io.micronaut.context.annotation.ConfigurationProperties
+
+@ConfigurationProperties("citybikeapp")
+class PaginationConfig @ConfigurationInject constructor(
+    val defaultPageSize: Int
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StationDao.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StationDao.kt
@@ -1,19 +1,43 @@
 package com.mtuomiko.citybikeapp.dao
 
+import com.mtuomiko.citybikeapp.common.model.Station
 import com.mtuomiko.citybikeapp.common.model.StationDetails
+import com.mtuomiko.citybikeapp.common.model.StationLimited
 import com.mtuomiko.citybikeapp.dao.entity.StationEntity
+import com.mtuomiko.citybikeapp.dao.model.StationProjection
 import com.mtuomiko.citybikeapp.dao.repository.StationRepository
+import io.micronaut.data.model.Pageable
+import io.micronaut.data.model.Sort
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 
 @Singleton
 class StationDao(
-    @Inject private val stationRepository: StationRepository
+    @Inject private val stationRepository: StationRepository,
+    @Inject private val paginationConfig: PaginationConfig
 ) {
     fun getStationById(stationId: Int): StationDetails? = stationRepository.findById(stationId)
-        .orElse(null)?.toModel()
+        .orElse(null)?.toDetailsModel()
 
-    private fun StationEntity.toModel(): StationDetails = StationDetails(
+    fun getAllStationsLimited() = stationRepository.getAll().map { StationLimited(it.id, it.nameFinnish) }
+
+    fun getStations(searchTokens: List<String>, page: Int): List<Station> {
+        if (searchTokens.isEmpty()) return getStations(page)
+
+        // TODO: Escape regex or otherwise sanitize!
+        return stationRepository.searchUsingRegex(
+            pattern = searchTokens.joinToString("|"),
+            limit = paginationConfig.defaultPageSize,
+            offset = paginationConfig.defaultPageSize * page
+        )
+    }
+
+    private fun getStations(page: Int): List<Station> {
+        val pageable = Pageable.from(page, paginationConfig.defaultPageSize, Sort.of(Sort.Order.asc("id")))
+        return stationRepository.list(pageable).map { it.toModel() }
+    }
+
+    private fun StationEntity.toDetailsModel(): StationDetails = StationDetails(
         id,
         nameFinnish,
         nameSwedish,
@@ -26,5 +50,14 @@ class StationDao(
         capacity,
         longitude,
         latitude
+    )
+
+    private fun StationProjection.toModel() = Station(
+        id,
+        nameFinnish,
+        addressFinnish,
+        cityFinnish,
+        operator,
+        capacity
     )
 }

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/mapper/StationRowMapper.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/mapper/StationRowMapper.kt
@@ -1,0 +1,18 @@
+package com.mtuomiko.citybikeapp.dao.mapper
+
+import com.mtuomiko.citybikeapp.common.model.Station
+import org.jdbi.v3.core.mapper.RowMapper
+import org.jdbi.v3.core.statement.StatementContext
+import java.sql.ResultSet
+
+@Suppress("MagicNumber")
+class StationRowMapper : RowMapper<Station> {
+    override fun map(resultSet: ResultSet, ctx: StatementContext): Station = Station(
+        id = resultSet.getInt(2),
+        nameFinnish = resultSet.getString(3),
+        addressFinnish = resultSet.getString(4),
+        cityFinnish = resultSet.getString(5),
+        operator = resultSet.getString(6),
+        capacity = resultSet.getInt(7)
+    )
+}

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/StationLimitedProjection.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/StationLimitedProjection.kt
@@ -1,0 +1,9 @@
+package com.mtuomiko.citybikeapp.dao.model
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class StationLimitedProjection(
+    val id: Int,
+    val nameFinnish: String
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/StationProjection.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/model/StationProjection.kt
@@ -1,0 +1,13 @@
+package com.mtuomiko.citybikeapp.dao.model
+
+import io.micronaut.core.annotation.Introspected
+
+@Introspected
+class StationProjection(
+    val id: Int,
+    val nameFinnish: String,
+    val addressFinnish: String,
+    val cityFinnish: String,
+    val operator: String,
+    val capacity: Int
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/StationRepository.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/StationRepository.kt
@@ -1,9 +1,14 @@
 package com.mtuomiko.citybikeapp.dao.repository
 
+import com.mtuomiko.citybikeapp.common.model.Station
 import com.mtuomiko.citybikeapp.common.model.StationNew
 import com.mtuomiko.citybikeapp.dao.entity.StationEntity
+import com.mtuomiko.citybikeapp.dao.mapper.StationRowMapper
 import com.mtuomiko.citybikeapp.dao.model.StationInsert
+import com.mtuomiko.citybikeapp.dao.model.StationLimitedProjection
+import com.mtuomiko.citybikeapp.dao.model.StationProjection
 import io.micronaut.data.jdbc.annotation.JdbcRepository
+import io.micronaut.data.model.Pageable
 import io.micronaut.data.repository.PageableRepository
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.withHandleUnchecked
@@ -33,21 +38,57 @@ abstract class StationRepository(
     )
     private val columns = stationMapping.keys.toList()
     private val bindValues = stationMapping.values.toList()
+    private val stationMapper = StationRowMapper()
 
     @Transactional
     fun saveInBatchIgnoringConflicts(stations: List<StationNew>): Int {
         val now = instantSource.instant()
-        val insertStations = stations.map { StationInsert.from(it, now) }
+        val stationInserts = stations.map { StationInsert.from(it, now) }
 
         return jdbi.withHandleUnchecked { handle ->
             val batch = handle
                 .prepareBatch("INSERT INTO station (<columns>) VALUES (<values>) ON CONFLICT (id) DO NOTHING")
                 .defineList("columns", columns)
                 .defineList("values", bindValues)
-            insertStations.forEach {
+            stationInserts.forEach {
                 batch.bindBean(it).add()
             }
             batch.execute().size
         }
     }
+
+    /**
+     * trgm_ops indexing (for speeding up regex matching) is not setup since the amount of station rows is in practice
+     * fairly small and planner will not use the index. Also, said indexing cannot not be used for keyset pagination as
+     * match_count depends on the search pattern.
+     */
+    @Transactional
+    fun searchUsingRegex(pattern: String, limit: Int, offset: Int): List<Station> {
+        val sql = """
+        SELECT match_count, id, name_finnish, address_finnish, city_finnish, operator, capacity FROM station, LATERAL (
+            SELECT count(*) as match_count
+            FROM regexp_matches(lower(
+                name_finnish || ' ' || address_finnish || ' ' || name_swedish || ' ' || address_swedish || ' ' ||
+                name_english
+            ), :pattern, 'g')
+        ) as match_count_table
+        WHERE name_finnish || ' ' || address_finnish || ' ' || name_swedish || ' ' || address_swedish || ' ' ||
+            name_english ~* :pattern
+        ORDER BY match_count DESC, id ASC
+        LIMIT :limit OFFSET :offset;
+        """.trimIndent()
+
+        return jdbi.withHandleUnchecked { handle ->
+            handle.createQuery(sql)
+                .bind("pattern", pattern)
+                .bind("limit", limit)
+                .bind("offset", offset)
+                .map(stationMapper)
+                .list()
+        }
+    }
+
+    abstract fun getAll(): List<StationLimitedProjection>
+
+    abstract fun list(pageable: Pageable): List<StationProjection>
 }

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/svc/StationService.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/svc/StationService.kt
@@ -1,6 +1,7 @@
 package com.mtuomiko.citybikeapp.svc
 
 import com.mtuomiko.citybikeapp.common.TIMEZONE
+import com.mtuomiko.citybikeapp.common.model.Station
 import com.mtuomiko.citybikeapp.dao.StationDao
 import com.mtuomiko.citybikeapp.dao.StatisticsDao
 import com.mtuomiko.citybikeapp.svc.model.StationStatistics
@@ -15,6 +16,12 @@ class StationService(
     @Inject private val statisticsDao: StatisticsDao
 ) {
     fun getStationById(stationId: Int) = stationDao.getStationById(stationId)
+
+    fun getAllStationsLimited() = stationDao.getAllStationsLimited()
+
+    fun getStations(searchTokens: List<String>, page: Int): List<Station> {
+        return stationDao.getStations(searchTokens, page)
+    }
 
     fun getStationStatistics(stationId: Int, fromDate: LocalDate?, toDate: LocalDate?): StationStatistics {
         // Interpret query dates to be in local Helsinki time

--- a/citybikeapp-backend/src/main/resources/application.yml
+++ b/citybikeapp-backend/src/main/resources/application.yml
@@ -36,6 +36,7 @@ flyway:
       enabled: true
       defaultSchema: citybikeapp
 citybikeapp:
+  defaultPageSize: ${CITYBIKEAPP_DEFAULT_PAGE_SIZE:50}
   dataLoader:
     batchSize: ${CITYBIKEAPP_DATALOADER_BATCH_SIZE:1000}
     minimumJourneyDistance: ${CITYBIKEAPP_DATALOADER_MIN_DISTANCE:10}

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/StationApiTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/StationApiTest.kt
@@ -1,0 +1,111 @@
+package com.mtuomiko.citybikeapp
+
+import com.mtuomiko.citybikeapp.api.model.APIStation
+import com.mtuomiko.citybikeapp.api.model.APIStationDetails
+import com.mtuomiko.citybikeapp.api.model.APIStationLimited
+import com.mtuomiko.citybikeapp.api.model.APIStationStatistics
+import com.mtuomiko.citybikeapp.api.model.StationDetailsWithStatisticsResponse
+import com.mtuomiko.citybikeapp.api.model.StationsLimitedResponse
+import com.mtuomiko.citybikeapp.api.model.StationsResponse
+import com.mtuomiko.citybikeapp.dao.builder.StationEntityBuilder
+import com.mtuomiko.citybikeapp.dao.entity.StationEntity
+import com.mtuomiko.citybikeapp.dao.repository.StationRepository
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.BlockingHttpClient
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class StationApiTest {
+
+    @Inject
+    @field:Client("/station")
+    private lateinit var stationClient: HttpClient
+
+    @Inject
+    lateinit var stationRepository: StationRepository
+
+    private lateinit var client: BlockingHttpClient
+    private lateinit var testStations: List<StationEntity>
+
+    @BeforeEach
+    fun setup() {
+        client = stationClient.toBlocking()
+
+        val newStations = List(10) { StationEntityBuilder().id(it + 1).build() } +
+            List(10) {
+                StationEntityBuilder().id(it + 11)
+                    .nameFinnish("Toinen Paikka")
+                    .nameSwedish("Andra Platsen")
+                    .nameEnglish("Other Place")
+                    .build()
+            }
+        val createdStations = stationRepository.saveAll(newStations)
+        testStations = createdStations.toList()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        stationRepository.deleteAll()
+    }
+
+    @Test
+    fun `All stations with limited information endpoint responds successfully`() {
+        val request = HttpRequest.GET<Any>("/limited")
+        val response = client.exchange(request, StationsLimitedResponse::class.java)
+
+        val expected = stationRepository.findAll().map { APIStationLimited(it.id, it.nameFinnish) }
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+        assertThat(response.body()!!.stations).hasSize(testStations.size)
+        assertThat(response.body()!!.stations).containsExactlyInAnyOrderElementsOf(expected)
+    }
+
+    @Test
+    fun `Single station endpoint responds with details`() {
+        val testStation = testStations.last()
+        val request = HttpRequest.GET<Any>("/${testStation.id}")
+        val response = client.exchange(request, StationDetailsWithStatisticsResponse::class.java)
+
+        val expectedStationsDetails = with(testStation) {
+            APIStationDetails(
+                id,
+                nameFinnish,
+                nameSwedish,
+                nameEnglish,
+                addressFinnish,
+                addressSwedish,
+                cityFinnish,
+                citySwedish,
+                operator,
+                capacity,
+                longitude,
+                latitude
+            )
+        }
+        val expectedStatistics = APIStationStatistics(0, 0, 0.0, 0.0, emptyList(), emptyList())
+
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+        assertThat(response.body()!!.station).isEqualTo(expectedStationsDetails)
+        assertThat(response.body()!!.statistics).isEqualTo(expectedStatistics)
+    }
+
+    @Test
+    fun `Stations endpoint can be used with search term`() {
+        val request = HttpRequest.GET<Any>("?search=toinen")
+        val response = client.exchange(request, StationsResponse::class.java)
+
+        val expected = testStations
+            .filter { it.nameFinnish.contains("toinen", ignoreCase = true) }
+            .map { with(it) { APIStation(id, nameFinnish, addressFinnish, cityFinnish, operator, capacity) } }
+
+        assertThat(response.status).isEqualTo(HttpStatus.OK)
+        assertThat(response.body()!!.stations).containsExactlyInAnyOrderElementsOf(expected)
+    }
+}

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StationRepositoryTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StationRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.mtuomiko.citybikeapp.dao
 
+import com.mtuomiko.citybikeapp.dao.builder.StationEntityBuilder
 import com.mtuomiko.citybikeapp.dao.entity.StationEntity
 import com.mtuomiko.citybikeapp.dao.repository.StationRepository
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
@@ -12,7 +13,7 @@ private class StationRepositoryTest(
 ) {
     @Test
     fun `Valid station entity can be saved and queried`() {
-        val stationEntity = StationBuilder().build()
+        val stationEntity = StationEntityBuilder().build()
 
         val returnedStation = stationRepository.save(stationEntity)
 

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDaoTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDaoTest.kt
@@ -1,5 +1,6 @@
 package com.mtuomiko.citybikeapp.dao
 
+import com.mtuomiko.citybikeapp.dao.builder.TopStationsQueryResultBuilder
 import com.mtuomiko.citybikeapp.dao.repository.JourneyRepository
 import io.mockk.every
 import io.mockk.mockk

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/builder/StationEntityBuilder.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/builder/StationEntityBuilder.kt
@@ -1,8 +1,8 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.builder
 
 import com.mtuomiko.citybikeapp.dao.entity.StationEntity
 
-class StationBuilder {
+class StationEntityBuilder {
     var id: Int = 0
     var nameFinnish: String = "Joku Paikka"
     var nameSwedish: String = "Någon Plats"
@@ -18,6 +18,8 @@ class StationBuilder {
 
     fun id(id: Int) = apply { this.id = id }
     fun nameFinnish(name: String) = apply { this.nameFinnish = name }
+    fun nameSwedish(name: String) = apply { this.nameSwedish = name }
+    fun nameEnglish(name: String) = apply { this.nameEnglish = name }
 
     fun build() = StationEntity(
         id,

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/builder/TopStationsQueryResultBuilder.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/builder/TopStationsQueryResultBuilder.kt
@@ -1,4 +1,4 @@
-package com.mtuomiko.citybikeapp.dao
+package com.mtuomiko.citybikeapp.dao.builder
 
 import com.mtuomiko.citybikeapp.dao.model.TopStationsQueryResult
 

--- a/citybikeapp-frontend/.eslintrc.js
+++ b/citybikeapp-frontend/.eslintrc.js
@@ -40,10 +40,7 @@ module.exports = {
       "double",
       { avoidEscape: true }
     ],
-    semi: [
-      "error",
-      "always"
-    ],
+    semi: "off",
     "@typescript-eslint/semi": [
       "error",
       "always"

--- a/citybikeapp-frontend/src/App.tsx
+++ b/citybikeapp-frontend/src/App.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { Outlet } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 
 const App = () => {
   return (
     <div>
       <p>Root App works!</p>
+      <Link to={"/stations"}>Stations list</Link>
       <Outlet />
     </div>
   );

--- a/citybikeapp-frontend/src/components/StationDetailsView.tsx
+++ b/citybikeapp-frontend/src/components/StationDetailsView.tsx
@@ -3,7 +3,7 @@ import { Link, useParams } from "react-router-dom";
 import { StationStatistics, StationDetailsWithStatisticsResponse, TopStation, StationDetails } from "generated";
 import { stationApi } from "clients";
 
-const StationDetails = () => {
+const StationDetailsView = () => {
   const params = useParams();
   const stationId = Number(params.stationId);
   const [response, setResponse] = useState<StationDetailsWithStatisticsResponse | undefined>(undefined);
@@ -39,7 +39,7 @@ const StationDetails = () => {
       <h3>{name}</h3>
       {stations.map(station =>
         <div key={station.id}>
-          <span><Link to={`/station/${station.id}`}>{station.nameFinnish}</Link>, {station.journeyCount} journeys</span>
+          <span><Link to={`/stations/${station.id}`}>{station.nameFinnish}</Link>, {station.journeyCount} journeys</span>
         </div>
       )}
     </div >
@@ -60,7 +60,7 @@ const StationDetails = () => {
       <li>longitude: {details.longitude}</li>
       <li>latitude: {details.latitude}</li>
     </ul>
-  )
+  );
 
   return (
     <div>
@@ -70,4 +70,4 @@ const StationDetails = () => {
   );
 };
 
-export default StationDetails;
+export default StationDetailsView;

--- a/citybikeapp-frontend/src/components/StationList.tsx
+++ b/citybikeapp-frontend/src/components/StationList.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { StationsLimitedResponse } from "generated";
+import { stationApi } from "clients";
+
+const StationList = () => {
+  const [response, setResponse] = useState<StationsLimitedResponse | undefined>(undefined);
+  useEffect(() => {
+    const getStation = async () => {
+      const response = await stationApi.getAllStationsLimited();
+      setResponse(response.data);
+    };
+
+    void getStation();
+  }, []);
+
+  if (response === undefined) return null;
+
+  return (
+    <div>
+      <ul>
+        {response.stations.map(stationLimited =>
+          <div key={stationLimited.id}>
+            <span><Link to={`/stations/${stationLimited.id}`}>{stationLimited.nameFinnish}</Link></span>
+          </div>)}
+      </ul>
+    </div>
+  );
+};
+
+export default StationList;

--- a/citybikeapp-frontend/src/index.tsx
+++ b/citybikeapp-frontend/src/index.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "App";
-import StationDetails from "components/StationDetails";
+import StationDetailsView from "components/StationDetailsView";
+import StationList from "components/StationList";
 
 const router = createBrowserRouter([
   {
@@ -10,8 +11,12 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       {
-        path: "station/:stationId",
-        element: <StationDetails />
+        path: "stations",
+        element: <StationList />
+      },
+      {
+        path: "stations/:stationId",
+        element: <StationDetailsView />
       }
     ]
   },


### PR DESCRIPTION
* Limited view endpoint `/station/limited`: returns all endpoints but only a limited view. Currently amount of stations in practice is fairly small so this should be ok.
* Station search and pagination endpoint `/station`: return more information (still not everything) but only in pages.
  * Search is done using query params (`?search=foo+bar`) and regex matching (**TODO: sanitize or escape!**)
    * Limit to maximum of three search terms and minimum search term length of 3 chars
  * Pagination requires order
    * Without search string, sort by station `id`
    * With search, sort by regex match count and secondarily by `id`
* Happy path testing for said endpoints
* Page size configurable with env var `CITYBIKEAPP_DEFAULT_PAGE_SIZE`
* List all stations with the limited endpoint on frontend
* Add lint & build pipeline for frontend