### PR TITLE
Upgrade Micronaut to 3.8.0, clean warnings

### DIFF
--- a/citybikeapp-backend/build.gradle.kts
+++ b/citybikeapp-backend/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.jetbrains.kotlin.kapt").version("1.6.21")
     id("org.jetbrains.kotlin.plugin.allopen").version("1.6.21")
     id("com.github.johnrengelman.shadow").version("7.1.2")
-    id("io.micronaut.application").version("3.6.3")
+    id("io.micronaut.application").version("3.6.7")
 
     id("io.gitlab.arturbosch.detekt").version("1.22.0")
     id("com.diffplug.spotless").version("6.12.0")
@@ -50,10 +50,13 @@ dependencies {
     implementation("io.micronaut:micronaut-validation")
     implementation("com.github.doyaaaaaken:kotlin-csv-jvm:1.7.0")
     implementation("io.github.microutils:kotlin-logging-jvm:2.1.23") // match logback version
-    implementation("io.micronaut.openapi:micronaut-openapi") // include annotations
+    implementation("io.micronaut.openapi:micronaut-openapi") { // include annotations
+        exclude(group = "org.slf4j", module = "slf4j-nop") // for some reason openapi tries to include this
+    }
     implementation("org.mapstruct:mapstruct:1.5.3.Final")
 
     compileOnly("jakarta.persistence:jakarta.persistence-api:3.0.0")
+    compileOnly("com.google.code.findbugs:jsr305") // "unknown enum constant When.MAYBE" warning on kaptKotlin task
 
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("org.postgresql:postgresql")
@@ -64,6 +67,9 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:testcontainers")
+
+    // "unknown enum constant GenerationType.IDENTITY" warning on kaptTestKotlin task
+    testCompileOnly("jakarta.persistence:jakarta.persistence-api:3.0.0")
 }
 
 application {
@@ -101,7 +107,7 @@ configurations.all {
             substitute(module("io.micronaut:micronaut-jackson-databind"))
                 .using(module("io.micronaut.serde:micronaut-serde-jackson:1.3.3"))
         }
-        force("com.github.ben-manes.caffeine:caffeine:3.0.3")
+        force("com.github.ben-manes.caffeine:caffeine:3.0.3") // jdbi has direct dependency
     }
 }
 

--- a/citybikeapp-backend/gradle.properties
+++ b/citybikeapp-backend/gradle.properties
@@ -1,2 +1,2 @@
-micronautVersion=3.7.4
+micronautVersion=3.8.0
 kotlinVersion=1.6.10

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/StationController.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/StationController.kt
@@ -23,7 +23,10 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.inject.Inject
+import mu.KotlinLogging
 import java.time.LocalDate
+
+private val logger = KotlinLogging.logger {}
 
 @ExecuteOn(TaskExecutors.IO)
 @Controller("/station")
@@ -69,6 +72,8 @@ class StationController(
         @Parameter(example = "25") @QueryValue @Nullable
         pageSize: Int?
     ): StationsResponse {
+        logger.debug { "Fetching stations with search: $search, page: $page, pageSize: $pageSize" }
+
         val searchTokens = search?.split('+') ?: emptyList()
         if (searchTokens.size > MAX_SEARCH_TERM_COUNT || searchTokens.any { it.length < MIN_SEARCH_TERM_LENGTH }) {
             throw BadRequestException("check search terms")

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/JourneyRepositoryTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/JourneyRepositoryTest.kt
@@ -15,11 +15,11 @@ class JourneyRepositoryTest(
      */
     @Test
     fun `Trip statistics query can be run`() {
-        val result = journeyRepository.getJourneyStatisticsByStationId(100)
+        journeyRepository.getJourneyStatisticsByStationId(100)
     }
 
     @Test
     fun `Top stations query can be run`() {
-        val result = journeyRepository.getTopStationsByStationId(100)
+        journeyRepository.getTopStationsByStationId(100)
     }
 }


### PR DESCRIPTION
* Micronaut version to `3.8.0`
* Update gradle build with dependencies to get rid of warnings
  * `kapt` annotation processing tasks showing "Enum not found" warnings are, according to Micronaut docs, not relevant but look annoying
  * Something in the new version of `micronaut-openapi` wanted to pull in `slf4j-nop` no-op logger even though `logback` should be present on the classpath, so excluding that