### PR TITLE
Add basic journey list implementation to frontend

### DIFF
--- a/citybikeapp-backend/gen/api.yml
+++ b/citybikeapp-backend/gen/api.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: City Bike App API
-  version: 0.0.8a
+  version: 0.0.9a
 paths:
   /health:
     get:
@@ -49,6 +49,8 @@ paths:
           enum:
           - departureAt
           - arrivalAt
+          - distance
+          - duration
       - name: direction
         in: query
         description: Sort results in this direction
@@ -220,10 +222,10 @@ components:
           nullable: true
     Journey:
       required:
+      - arrivalAt
       - arrivalStationId
-      - arrivalTime
+      - departureAt
       - departureStationId
-      - departureTime
       - distance
       - duration
       - id
@@ -231,10 +233,10 @@ components:
       properties:
         id:
           type: string
-        departureTime:
+        departureAt:
           type: string
           format: date-time
-        arrivalTime:
+        arrivalAt:
           type: string
           format: date-time
         departureStationId:

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/Application.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/Application.kt
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.info.Info
 @OpenAPIDefinition(
     info = Info(
         title = "City Bike App API",
-        version = "0.0.8a"
+        version = "0.0.9a"
     )
 )
 @OpenAPIInclude(classes = [HealthEndpoint::class])

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/JourneyController.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/JourneyController.kt
@@ -3,7 +3,6 @@ package com.mtuomiko.citybikeapp.api
 import com.mtuomiko.citybikeapp.api.model.APIJourney
 import com.mtuomiko.citybikeapp.api.model.CursorMeta
 import com.mtuomiko.citybikeapp.api.model.JourneysResponse
-import com.mtuomiko.citybikeapp.common.TIMEZONE
 import com.mtuomiko.citybikeapp.common.model.Journey
 import com.mtuomiko.citybikeapp.svc.JourneyService
 import io.micronaut.http.annotation.Controller
@@ -15,7 +14,6 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
-import java.time.ZonedDateTime
 
 @ExecuteOn(TaskExecutors.IO)
 @Controller("/journey")
@@ -32,7 +30,7 @@ class JourneyController(
                 description = "Sort results by this property",
                 schema = Schema(
                     type = "string",
-                    allowableValues = ["departureAt", "arrivalAt"],
+                    allowableValues = ["departureAt", "arrivalAt", "distance", "duration"],
                     defaultValue = "departureAt"
                 )
             ),
@@ -69,8 +67,8 @@ class JourneyController(
     private fun Journey.toApi() =
         APIJourney(
             id.toString(),
-            ZonedDateTime.ofInstant(departureAt, TIMEZONE),
-            ZonedDateTime.ofInstant(arrivalAt, TIMEZONE),
+            departureAt,
+            arrivalAt,
             departureStationId,
             arrivalStationId,
             distance,

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
@@ -2,7 +2,7 @@ package com.mtuomiko.citybikeapp.api.model
 
 import io.micronaut.serde.annotation.Serdeable
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.ZonedDateTime
+import java.time.Instant
 
 @Serdeable
 @Schema(name = "StationDetails")
@@ -71,8 +71,8 @@ class CursorMeta(
 @Schema(name = "Journey")
 data class APIJourney(
     val id: String,
-    val departureTime: ZonedDateTime,
-    val arrivalTime: ZonedDateTime,
+    val departureAt: Instant,
+    val arrivalAt: Instant,
     val departureStationId: Int,
     val arrivalStationId: Int,
     val distance: Int,

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/JourneyApiTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/JourneyApiTest.kt
@@ -2,7 +2,6 @@ package com.mtuomiko.citybikeapp
 
 import com.mtuomiko.citybikeapp.api.model.APIJourney
 import com.mtuomiko.citybikeapp.api.model.JourneysResponse
-import com.mtuomiko.citybikeapp.common.TIMEZONE
 import com.mtuomiko.citybikeapp.dao.builder.JourneyEntityBuilder
 import com.mtuomiko.citybikeapp.dao.builder.StationEntityBuilder
 import com.mtuomiko.citybikeapp.dao.entity.JourneyEntity
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Test
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.Instant
-import java.time.ZonedDateTime
 
 @MicronautTest
 class JourneyApiTest {
@@ -206,8 +204,8 @@ class JourneyApiTest {
 
     private fun JourneyEntity.toApi() = APIJourney(
         id.toString(),
-        ZonedDateTime.ofInstant(departureAt, TIMEZONE),
-        ZonedDateTime.ofInstant(arrivalAt, TIMEZONE),
+        departureAt,
+        arrivalAt,
         departureStationId,
         arrivalStationId,
         distance,

--- a/citybikeapp-frontend/.eslintrc.js
+++ b/citybikeapp-frontend/.eslintrc.js
@@ -60,6 +60,14 @@ module.exports = {
         ]
       }
     ],
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksVoidReturn": {
+          "attributes": false
+        }
+      }
+    ],
     "import/order": [
       "error",
       {

--- a/citybikeapp-frontend/src/components/JourneyList.tsx
+++ b/citybikeapp-frontend/src/components/JourneyList.tsx
@@ -1,9 +1,95 @@
-import React from "react";
+import { Button, Link, Table, Tbody, Td, Th, Thead, Tr } from "@chakra-ui/react";
+import React, { useEffect, useState } from "react";
+import { Link as ReactRouterLink } from "react-router-dom";
+import { useStationsLimited } from "contexts/StationsLimitedContext";
+import { Direction, DirectionEnum } from "enums";
+import journeyService, { OrderBy } from "service/journey";
+import { Journey } from "types";
 
 const JourneyList = () => {
+  const { state } = useStationsLimited();
+  const [parameters] = useState<{
+    orderBy: OrderBy
+    direction: Direction
+    pageSize: number
+  }>({
+    orderBy: "departureAt",
+    direction: DirectionEnum.Descending,
+    pageSize: 25
+  });
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [journeys, setJourneys] = useState<Journey[]>([]);
+
+  useEffect(() => {
+    const getStation = async () => {
+      const response = await journeyService.getJourneys({
+        orderBy: parameters.orderBy,
+        direction: parameters.direction,
+        pageSize: parameters.pageSize,
+        cursor
+      }
+      );
+      setJourneys(response.journeys);
+      setCursor(response.cursor);
+    };
+
+    void getStation();
+  }, [parameters]);
+
+  const handleFetchMore = async () => {
+    if (cursor !== undefined && cursor !== null && cursor.length > 0) {
+      const response = await journeyService.getJourneys({
+        orderBy: parameters.orderBy,
+        direction: parameters.direction,
+        pageSize: parameters.pageSize,
+        cursor
+      });
+      setJourneys(current => current.concat(response.journeys));
+      setCursor(response.cursor);
+    }
+  };
+
+  if (state.stations.allIds.length === 0) return <div>Loading</div>;
+
   return (
     <div>
-      Not implemented
+      <Table>
+        <Thead>
+          <Tr>
+            <Th>Departure time</Th>
+            <Th>Arrival time</Th>
+            <Th>Departure station</Th>
+            <Th>Arrival station</Th>
+            <Th>Distance (km)</Th>
+            <Th>Duration (min.)</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {journeys.map(journey => (
+            <Tr key={journey.id}>
+              <Td>{journey.departureAt.toLocaleString("fi-FI")}</Td>
+              <Td>{journey.arrivalAt.toLocaleString("fi-FI")}</Td>
+              <Td>
+                <Link
+                  as={ReactRouterLink}
+                  to={`/stations/${journey.departureStationId}`}
+                >{state.stations.byId[journey.departureStationId].nameFinnish}</Link>
+              </Td>
+              <Td>
+                <Link
+                  as={ReactRouterLink}
+                  to={`/stations/${journey.arrivalStationId}`}
+                >{state.stations.byId[journey.arrivalStationId].nameFinnish}</Link>
+              </Td>
+              <Td>{journey.distance}</Td>
+              <Td>{journey.duration}</Td>
+            </Tr>
+          ))}
+          {(cursor !== undefined) &&
+            <Tr><Td colSpan={6}><Button onClick={handleFetchMore}>Load more</Button></Td></Tr>
+          }
+        </Tbody>
+      </Table>
     </div>
   );
 };

--- a/citybikeapp-frontend/src/components/StationDetailsView.tsx
+++ b/citybikeapp-frontend/src/components/StationDetailsView.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link as ReactRouterLink, useParams } from "react-router-dom";
+import { Link } from "@chakra-ui/react";
 import { StationStatistics, StationDetailsWithStatisticsResponse, TopStation, StationDetails } from "generated";
 import { stationApi } from "clients";
+import { useStationsLimited } from "contexts/StationsLimitedContext";
 
 const StationDetailsView = () => {
   const params = useParams();
+  const { state } = useStationsLimited();
   const stationId = Number(params.stationId);
   const [response, setResponse] = useState<StationDetailsWithStatisticsResponse | undefined>(undefined);
   useEffect(() => {
@@ -18,7 +21,7 @@ const StationDetailsView = () => {
     void getStation();
   }, [stationId]);
 
-  if (response === undefined) return null;
+  if (response === undefined || state.stations.allIds.length === 0) return null;
 
   const statistics = (statistics: StationStatistics) => (
     <>
@@ -39,7 +42,12 @@ const StationDetailsView = () => {
       <h3>{name}</h3>
       {stations.map(station =>
         <div key={station.id}>
-          <span><Link to={`/stations/${station.id}`}>{station.id}</Link>, {station.journeyCount} journeys</span>
+          <span>
+            <Link
+              as={ReactRouterLink}
+              to={`/stations/${station.id}`}
+            >{state.stations.byId[station.id].nameFinnish}</Link>, {station.journeyCount} journeys
+          </span>
         </div>
       )}
     </div >

--- a/citybikeapp-frontend/src/enums.ts
+++ b/citybikeapp-frontend/src/enums.ts
@@ -1,0 +1,5 @@
+export const DirectionEnum = {
+  Ascending: "asc",
+  Descending: "desc"
+} as const;
+export type Direction = typeof DirectionEnum[keyof typeof DirectionEnum];

--- a/citybikeapp-frontend/src/service/journey.ts
+++ b/citybikeapp-frontend/src/service/journey.ts
@@ -1,0 +1,45 @@
+import { journeyApi } from "clients";
+import { Direction } from "enums";
+import { Journey as APIJourney } from "generated";
+import { Journey } from "types";
+
+export type OrderBy = "departureAt" | "arrivalAt" | "distance" | "duration";
+
+export interface JourneyParameters {
+  orderBy: OrderBy
+  direction: Direction
+  pageSize: number
+  cursor: string | undefined
+}
+
+const parseJourney = (journey: APIJourney): Journey => {
+  const parsedJourney = {
+    ...journey,
+    departureAt: new Date(journey.departureAt),
+    arrivalAt: new Date(journey.arrivalAt)
+  };
+  return parsedJourney;
+};
+
+interface JourneysResponse {
+  journeys: Journey[]
+  cursor: string | undefined
+}
+
+const getJourneys = async (parameters: JourneyParameters): Promise<JourneysResponse> => {
+  const response = await journeyApi.getJourneys(
+    parameters.orderBy,
+    parameters.direction,
+    parameters.pageSize,
+    parameters.cursor
+  );
+
+  const journeys = response.data.journeys.map(journey => parseJourney(journey));
+  const cursor = response.data.meta.nextCursor ?? undefined;
+  return {
+    journeys,
+    cursor
+  };
+};
+
+export default { getJourneys };

--- a/citybikeapp-frontend/src/types.ts
+++ b/citybikeapp-frontend/src/types.ts
@@ -1,1 +1,10 @@
+import { Journey as APIJourney } from "generated";
+
 export type ID = string;
+
+type JourneyWithoutTimestampStrings = Omit<APIJourney, "departureAt" | "arrivalAt">;
+
+export type Journey = JourneyWithoutTimestampStrings & {
+  departureAt: Date
+  arrivalAt: Date
+};


### PR DESCRIPTION
* Basic implementation. Distance and duration units are not correct, and orderBy, direction and pageSize cannot be changed.
* But can paginate manually by loading more journeys on the same view
* Switched API timestamps away from `ZonedDateTime` since I didn't want to introduce a new library for parsing timestamp strings with zone identifier (for example "2021-07-27T11:27:36+03:00[Europe/Helsinki]").
  * Experimental EcmaScript Temporal APIs seem like they could handle those but too new a feature