### PR TITLE
Move backend error handling to single global handler

### DIFF
--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/GlobalExceptionHandler.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/GlobalExceptionHandler.kt
@@ -1,0 +1,42 @@
+package com.mtuomiko.citybikeapp.api
+
+import com.mtuomiko.citybikeapp.common.BadRequestError
+import com.mtuomiko.citybikeapp.common.CustomError
+import com.mtuomiko.citybikeapp.common.InnerError
+import com.mtuomiko.citybikeapp.common.NotFoundError
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Produces
+import io.micronaut.http.hateoas.JsonError
+import io.micronaut.http.hateoas.Link
+import io.micronaut.http.server.exceptions.ExceptionHandler
+import jakarta.inject.Singleton
+
+@Produces
+@Singleton
+@Requires(classes = [CustomError::class])
+class GlobalExceptionHandler : ExceptionHandler<CustomError, HttpResponse<JsonError>> {
+
+    override fun handle(request: HttpRequest<*>, exception: CustomError): HttpResponse<JsonError> {
+        val statusCode = getHttpStatus(exception)
+        val apiErrors = exception.innerErrors?.map { it.toJsonError() }
+
+        return HttpResponse.status<JsonError>(statusCode).body(
+            JsonError(exception.message)
+                .embedded("errors", apiErrors)
+                .link(Link.SELF, Link.of(request.uri))
+        )
+    }
+
+    private fun getHttpStatus(error: CustomError): HttpStatus {
+        return when (error) {
+            is BadRequestError -> HttpStatus.BAD_REQUEST
+            is NotFoundError -> HttpStatus.NOT_FOUND
+            else -> HttpStatus.INTERNAL_SERVER_ERROR
+        }
+    }
+
+    private fun InnerError.toJsonError() = JsonError(message).path(target)
+}

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/APIModels.kt
@@ -78,3 +78,10 @@ data class APIJourney(
     val distance: Int,
     val duration: Int
 )
+
+@Serdeable
+@Schema(name = "Error")
+class APIError(
+    val message: String,
+    val target: String?
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/Responses.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/api/model/Responses.kt
@@ -24,3 +24,10 @@ class JourneysResponse(
     val journeys: List<APIJourney>,
     val meta: CursorMeta
 )
+
+@Serdeable
+class ErrorResponse(
+    val message: String?,
+    val status: Int,
+    val errors: List<APIError>?
+)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/Errors.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/common/Errors.kt
@@ -1,0 +1,28 @@
+package com.mtuomiko.citybikeapp.common
+
+open class CustomError(
+    message: String = "Unknown error",
+    cause: Exception? = null,
+    val innerErrors: List<InnerError>? = null
+) : Exception(message, cause)
+
+class InnerError(
+    val message: String,
+    val target: String? = null
+)
+
+class NotFoundError(
+    message: String = "Not found",
+    cause: Exception? = null,
+    innerErrors: List<InnerError>? = null
+) : CustomError(message, cause, innerErrors)
+
+class BadRequestError(
+    message: String = "Bad request",
+    cause: Exception? = null,
+    innerErrors: List<InnerError>? = null
+) : CustomError(message, cause, innerErrors)
+
+object ErrorMessages {
+    const val INVALID_QUERY_PARAMETER = "invalid query parameter"
+}


### PR DESCRIPTION
* Use the same error format as default error handlers (https://github.com/blongden/vnd.error). The error specs are not in the API specs though.