### PR TITLE
Bug fix: never return more top stations than specified

### DIFF
--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDao.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDao.kt
@@ -20,17 +20,25 @@ class StatisticsDao(
         return journeyRepository.getJourneyStatisticsByStationId(stationId, from, to).await()
     }
 
-    suspend fun getTopStationsByStationId(stationId: Int, from: Instant?, to: Instant?): TopStations {
-        val topStationsQueryResult = journeyRepository.getTopStationsByStationId(stationId, from, to).await()
+    suspend fun getTopStationsByStationId(
+        stationId: Int,
+        from: Instant?,
+        to: Instant?,
+        limitPerDirection: Int = 5
+    ): TopStations {
+        val topStationsQueryResult =
+            journeyRepository.getTopStationsByStationId(stationId, limitPerDirection, from, to).await()
 
         val arrivalStations = topStationsQueryResult
             .filter { it.arrivalStationId == stationId }
             .sortedByDescending { it.journeyCount }
+            .take(limitPerDirection)
             .map { TopStation(it.departureStationId, it.journeyCount) }
 
         val departureStations = topStationsQueryResult
             .filter { it.departureStationId == stationId }
             .sortedByDescending { it.journeyCount }
+            .take(limitPerDirection)
             .map { TopStation(it.arrivalStationId, it.journeyCount) }
 
         return TopStations(forArrivingHere = arrivalStations, forDepartingTo = departureStations)

--- a/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/JourneyRepository.kt
+++ b/citybikeapp-backend/src/main/kotlin/com/mtuomiko/citybikeapp/dao/repository/JourneyRepository.kt
@@ -119,9 +119,9 @@ class JourneyRepository(private val ctx: DSLContext) {
 
     fun getTopStationsByStationId(
         stationId: Int,
+        limitPerDirection: Int,
         from: Instant? = null,
-        to: Instant? = null,
-        limitPerDirection: Int = 5
+        to: Instant? = null
     ): Deferred<List<TopStationsQueryResult>> {
         val departureStationsCondition =
             JOURNEY.ARRIVAL_STATION_ID.eq(stationId).andDepartureTimestampCondition(from, to)

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/JourneyRepositoryTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/JourneyRepositoryTest.kt
@@ -20,6 +20,6 @@ class JourneyRepositoryTest(
 
     @Test
     fun `Top stations query can be run`() {
-        journeyRepository.getTopStationsByStationId(100)
+        journeyRepository.getTopStationsByStationId(100, 5)
     }
 }

--- a/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDaoTest.kt
+++ b/citybikeapp-backend/src/test/kotlin/com/mtuomiko/citybikeapp/dao/StatisticsDaoTest.kt
@@ -14,7 +14,7 @@ class StatisticsDaoTest {
     private val statisticsDao = StatisticsDao(journeyRepository)
 
     @Test
-    fun `Top stations are split and sorted according to arriving and departing station ids and journey count `() {
+    fun `Top stations are split and sorted according to arriving and departing station ids and journey count`() {
         val testStationId = 1
         val testQueryResults = List(6) {
             TopStationsQueryResultBuilder().departureStationId(testStationId).arrivalStationId(100 + it)
@@ -26,12 +26,12 @@ class StatisticsDaoTest {
                 .build()
         }
 
-        every { journeyRepository.getTopStationsByStationId(testStationId) } returns CompletableDeferred(
+        every { journeyRepository.getTopStationsByStationId(testStationId, 6) } returns CompletableDeferred(
             testQueryResults
         )
 
         runBlocking {
-            val result = statisticsDao.getTopStationsByStationId(testStationId, null, null)
+            val result = statisticsDao.getTopStationsByStationId(testStationId, null, null, 6)
 
             val expectedStationIdsWhereDepartedFrom =
                 testQueryResults.filter { it.arrivalStationId == testStationId }.sortedByDescending { it.journeyCount }
@@ -43,14 +43,45 @@ class StatisticsDaoTest {
 
             // expect descending order
             assertThat(result.forArrivingHere).hasSize(6)
-            assertThat(result.forArrivingHere).isSortedAccordingTo { o1, o2 -> (o2.journeyCount - o1.journeyCount).toInt() }
+            assertThat(result.forArrivingHere).isSortedAccordingTo { o1, o2 ->
+                (o2.journeyCount - o1.journeyCount).toInt()
+            }
             assertThat(result.forArrivingHere.map { it.id }).containsExactlyElementsOf(
                 expectedStationIdsWhereDepartedFrom
             )
 
             assertThat(result.forDepartingTo).hasSize(6)
-            assertThat(result.forDepartingTo).isSortedAccordingTo { o1, o2 -> (o2.journeyCount - o1.journeyCount).toInt() }
+            assertThat(result.forDepartingTo).isSortedAccordingTo { o1, o2 ->
+                (o2.journeyCount - o1.journeyCount).toInt()
+            }
             assertThat(result.forDepartingTo.map { it.id }).containsExactlyElementsOf(expectedStationIdsWhereArrivedTo)
+        }
+    }
+
+    @Test
+    fun `Given query result with self referring top station, top station response does not exceed count limit`() {
+        val testStationId = 1
+        val testQueryResults = listOf(
+            TopStationsQueryResultBuilder().departureStationId(2).arrivalStationId(testStationId)
+                .journeyCount(10).build(),
+            TopStationsQueryResultBuilder().departureStationId(testStationId).arrivalStationId(testStationId)
+                .journeyCount(5).build()
+        )
+
+        every { journeyRepository.getTopStationsByStationId(testStationId, 1) } returns CompletableDeferred(
+            testQueryResults
+        )
+
+        runBlocking {
+            val result = statisticsDao.getTopStationsByStationId(testStationId, null, null, 1)
+
+            assertThat(result.forArrivingHere).hasSize(1)
+            assertThat(result.forArrivingHere.first().id).isEqualTo(2)
+            assertThat(result.forArrivingHere.first().journeyCount).isEqualTo(10)
+
+            assertThat(result.forDepartingTo).hasSize(1)
+            assertThat(result.forDepartingTo.first().id).isEqualTo(testStationId)
+            assertThat(result.forDepartingTo.first().journeyCount).isEqualTo(5)
         }
     }
 }


### PR DESCRIPTION
Station details endpoint could return 6 top stations for one direction (departure/arrival) in the station statistics. The specified maximum for the endpoint is 5.

Top stations results on the DB query level can include "self referring" results where the departing and arriving stations are the same station which is being queried. This is normal and it just means that it was popular to return the bike to the same location where it was picked up. Also the DB query does correctly limit the results, that is, it won't return more results per direction than what was specified.

Issue was with handling of said results. The code could include one result from the "the other direction's group" into the other direction's group. In practice you could get, for example: 
  * 5 top arrival stations of which one is a "self referring" top station
  * 6 top departing stations. Five of which are "normal", **AND ALSO** the extra one from the arrival stations (the self referring one)